### PR TITLE
chore: add bootloader docs and smoke test

### DIFF
--- a/.github/workflows/teof-ci.yml
+++ b/.github/workflows/teof-ci.yml
@@ -83,6 +83,19 @@ jobs:
           fi
           bash tools/doctor.sh
 
+      - name: Smoke test bootloader CLI (non-blocking)
+        shell: bash
+        run: |
+          set +e
+          python teof/bootloader.py --help > bootloader-help.log 2>&1
+          status=$?
+          if [ $status -ne 0 ]; then
+            echo "::warning::bootloader help failed (status $status)"
+            cat bootloader-help.log || true
+          fi
+          rm -f bootloader-help.log
+          exit 0
+
       # ---- Capsule baseline detection/verification ----
       - name: Detect capsule baseline
         id: detect

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -1,0 +1,34 @@
+# TEOF CLI Quick Reference
+
+The repository ships a minimal `teof` command for local smoke tests and sample artifact generation. It wraps the bundled ensemble scorer so contributors can validate changes without installing the full external CLI.
+
+## Installation
+
+```bash
+pip install -e .
+```
+
+## `teof brief`
+
+Run the bundled "brief" example through the ensemble scorer and emit artifacts under `artifacts/ocers_out/<timestamp>/`:
+
+```bash
+python -m teof.cli brief
+```
+
+Each invocation produces:
+
+- `*.ensemble.json` – ensemble scores for every input in `docs/examples/brief/inputs/`
+- `brief.json` – execution summary listing input files, output artifacts, and the UTC timestamp
+- `score.txt` – plain-text counter with the number of ensemble outputs
+- `latest/` – symlink (or directory fallback) pointing at the most recent run
+
+Use these artifacts as observational checks; they are not considered capsule canon.
+
+## Help & Diagnostics
+
+```bash
+python teof/bootloader.py --help
+```
+
+Use this smoke test to confirm the bootloader is importable and the CLI entry points are wired correctly. CI tracks the same command in a non-blocking step so regressions surface without blocking the pipeline.


### PR DESCRIPTION
## Summary
- document the repo-local teof CLI and its brief artifacts in docs/cli.md
- add a non-blocking smoke test that runs python teof/bootloader.py --help during teof-ci

## Alignment Note (L0–L3)
This change improves Observation/Coherence by surfacing CLI health signals in CI and giving operators a clear brief reference. No canon (governance/core/**) or capsule hashes modified.
