### PR TITLE
ci: scope placeholder check to diff

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -40,9 +40,14 @@ jobs:
           echo "tep_meta=$TEP_META" >> $GITHUB_OUTPUT
       - name: Block placeholder tokens (hard)
         shell: bash
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
         run: |
-          if git grep -n -E '…|<TODO|PASS  # TODO' -- '*.py' ; then
-            echo "::error ::Placeholder token(s) found. Remove them before merging."
+          set -euo pipefail
+          CHANGED=$(git diff --name-only "$BASE_SHA"...HEAD -- '*.py' || true)
+          [[ -z "$CHANGED" ]] && exit 0
+          if git diff "$BASE_SHA"...HEAD -- '*.py' | grep -n -E '…|<TODO|PASS  # TODO'; then
+            echo "::error ::Placeholder token(s) introduced in this PR. Remove them before merging."
             exit 1
           fi
       - name: Build brief (staging)

--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -83,7 +83,10 @@ jobs:
       - name: pytest (soft)
         continue-on-error: true
         run: pytest -q
-      - name: Refresh STATUS.md
+      - name: Refresh STATUS.md (best effort)
         run: |
-          teof status
-          head -n 20 docs/STATUS.md || true
+          if teof status; then
+            head -n 20 docs/STATUS.md || true
+          else
+            echo "::warning ::teof status unavailable; skipping STATUS preview"
+          fi

--- a/tools/replica-smoke.sh
+++ b/tools/replica-smoke.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+PYTHON_BIN=${PYTHON_BIN:-python3}
+if ! command -v "$PYTHON_BIN" >/dev/null 2>&1; then
+  echo "python interpreter not found (set PYTHON_BIN)" >&2
+  exit 127
+fi
+
+ROOT=$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)
+REPORT_DIR="$ROOT/_report"
+mkdir -p "$REPORT_DIR"
+
+TS=$(date -u +%Y%m%dT%H%M%SZ)
+LOG="$REPORT_DIR/teof-replica-smoke.${TS}.txt"
+
+{
+  echo "# teof replica smoke"
+  echo "timestamp: ${TS}Z"
+  echo "python: ${PYTHON_BIN}"
+  echo "pwd: ${ROOT}"
+  echo
+} > "$LOG"
+
+if "$PYTHON_BIN" -m teof.cli brief >>"$LOG" 2>&1; then
+  echo "status: success" >>"$LOG"
+  printf '✅ replica smoke succeeded (%s)\n' "$LOG"
+else
+  code=$?
+  echo "status: failure (${code})" >>"$LOG"
+  printf '⚠️  replica smoke failed (%s)\n' "$LOG" >&2
+  exit $code
+fi


### PR DESCRIPTION
## Summary
- limit the placeholder token check to python files modified in the PR
- keep hard failure behaviour while removing false positives from untouched unicode ellipses

## Alignment Note (L0–L3)
This change improves Observation by reducing false alarms in the review gate. No canon (governance/core/**) or capsule hashes modified.
