### PR TITLE
policy: add memory log scaffold

### DIFF
--- a/.github/workflows/pr-check.yml
+++ b/.github/workflows/pr-check.yml
@@ -50,6 +50,11 @@ jobs:
             echo "::error ::Placeholder token(s) introduced in this PR. Remove them before merging."
             exit 1
           fi
+
+      - name: Memory log policy
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+        run: python3 scripts/ci/check_memory_log.py
       - name: Build brief (staging)
         shell: bash
         run: |

--- a/docs/policy/iteration-memory.md
+++ b/docs/policy/iteration-memory.md
@@ -1,0 +1,27 @@
+# Iteration Memory & Capability Policy
+
+TEOF requires that every material change leave a signed breadcrumb that future operators can audit. The policy couples an append-only memory log with a CI gate that refuses untracked work.
+
+## Memory Log (L1–L3 compliance)
+
+- The canonical log lives at `memory/log.jsonl`.
+- Each JSONL record captures `ts`, `actor`, `summary`, `ref`, `artifacts`, and `signatures`.
+- Entries are append-only; prior records must never be rewritten.
+- Signatures: contributors append detached signature identifiers (PGP, sigchain URLs, etc.). Capsule promotions require ≥2 signers.
+
+## Capability Gate
+
+The CI step `check_memory_log.py` enforces:
+
+1. Any PR touching `extensions/`, `tools/`, `scripts/`, or `docs/` (except `memory/`) must append at least one log entry.
+2. The log diff must be append-only (baseline content is a strict prefix of the new file).
+3. New entries must be valid JSON containing the required fields.
+
+## Workflow
+
+1. Build or modify your change on a feature branch.
+2. Append a memory entry using `tools/memory/log-entry.sh`, referencing the branch/PR and any external receipt in `_report/`.
+3. Collect signatures as needed and include them in the entry’s `signatures` array.
+4. Open the PR with the alignment note; CI will fail if the log is missing or malformed.
+
+This scaffold satisfies the "Encounterable & Decentralized" directive by ensuring every replica can replay history from an auditable trail.

--- a/memory/README.md
+++ b/memory/README.md
@@ -1,0 +1,64 @@
+# TEOF Memory Scaffold
+
+TEOF tracks decision and experiment history in an append-only log stored at `memory/log.jsonl`. Each entry captures who made a change, what was attempted, and where the supporting diff or artifact lives. The memory scaffold is:
+
+- **Append-only:** Prior entries must never be rewritten. New entries are appended at the end of `memory/log.jsonl`.
+- **Signed:** Authors should append their signature digest in the `signatures` array. Threshold signing (≥2 signers) is required before promoting capsule changes.
+- **Mirrored:** Operators may mirror the log to external stores (S3, IPFS, etc.) for redundancy, but the Git repo remains the canonical source of truth.
+
+## Entry schema
+
+Each line in `memory/log.jsonl` is a JSON object with the following fields:
+
+| Field       | Description |
+|-------------|-------------|
+| `ts`        | UTC timestamp (`YYYY-MM-DDTHH:MM:SSZ`). |
+| `actor`     | Human or agent responsible for the change. |
+| `summary`   | Short description of the decision or experiment. |
+| `ref`       | Branch, PR, or commit hash linking to the work. |
+| `artifacts` | List of artifact paths or URLs (may be empty). |
+| `signatures`| Array of detached signature identifiers (may be empty if pending). |
+
+Example line:
+
+```json
+{"ts":"2025-09-17T04:20:00Z","actor":"codex","summary":"Document replica smoke flow","ref":"PR-26","artifacts":["tools/replica-smoke.sh"],"signatures":[]}
+```
+
+## Appending entries
+
+Use `tools/memory/log-entry.py` to append a new record safely:
+
+```bash
+python tools/memory/log-entry.py \
+  --summary "Ran replica smoke on new dataset" \
+  --ref PR-42 \
+  --artifact _report/teof-replica-smoke.20250917T040000Z.txt
+```
+
+The script stamps the current timestamp and actor (defaults to `git config user.name`), then appends a JSON line. You can add signature identifiers later using the same tool with `--signatures`.
+
+## Querying recent entries
+
+Use `tools/memory/query.py` to review the most recent decisions:
+
+```bash
+python tools/memory/query.py --limit 10
+```
+
+Filter by actor or reference substring:
+
+```bash
+python tools/memory/query.py --actor codex --limit 5
+python tools/memory/query.py --ref PR-28 --limit 3
+```
+
+The script prints the newest entries first, including artifact and signature metadata.
+
+## Policy
+
+- Every PR touching `extensions/`, `tools/`, `scripts/`, or `docs/` (excluding `memory/`) must append at least one memory entry.
+- CI enforces append-only behavior and rejects PRs that mutate existing records.
+- Attach signatures before promoting capsule changes or modifying governance DNA.
+
+Mirrors should watch for new lines and replicate them without re-ordering.

--- a/memory/log.jsonl
+++ b/memory/log.jsonl
@@ -1,0 +1,1 @@
+{"ts":"2025-09-17T04:25:00Z","actor":"codex","summary":"Scaffold persistent memory log and CI guard","ref":"branch:policy/persistent-memory","artifacts":["docs/policy/iteration-memory.md","scripts/ci/check_memory_log.py"],"signatures":[]}

--- a/scripts/ci/check_memory_log.py
+++ b/scripts/ci/check_memory_log.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python3
+"""Verify append-only memory log policy for memory/log.jsonl."""
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+WATCH_PREFIXES = (
+    "extensions/",
+    "tools/",
+    "scripts/",
+    "docs/",
+)
+LOG_PATH = Path("memory/log.jsonl")
+
+
+def _git_diff_name_only(base: str) -> list[str]:
+    result = subprocess.run(
+        ["git", "diff", "--name-only", f"{base}...HEAD"],
+        check=True,
+        capture_output=True,
+        text=True,
+    )
+    return [line for line in result.stdout.splitlines() if line.strip()]
+
+
+def _git_show(path: str, base: str) -> list[str]:
+    try:
+        result = subprocess.run(
+            ["git", "show", f"{base}:{path}"],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        return result.stdout.splitlines()
+    except subprocess.CalledProcessError:
+        return []
+
+
+def main() -> int:
+    base_sha = os.environ.get("BASE_SHA")
+    if not base_sha:
+        print("BASE_SHA not provided", file=sys.stderr)
+        return 2
+
+    if not LOG_PATH.exists():
+        print("::error ::memory/log.jsonl missing")
+        return 1
+
+    changed_paths = _git_diff_name_only(base_sha)
+    watched_changes = [p for p in changed_paths if any(p.startswith(prefix) for prefix in WATCH_PREFIXES) and not p.startswith("docs/policy/") and not p.startswith("docs/deploy/") and p != "memory/log.jsonl"]
+
+    log_changed = "memory/log.jsonl" in changed_paths
+    if watched_changes and not log_changed:
+        print("::error ::changes detected but memory/log.jsonl not updated")
+        return 1
+
+    old_lines = _git_show("memory/log.jsonl", base_sha)
+    new_lines = LOG_PATH.read_text(encoding="utf-8").splitlines()
+
+    if old_lines:
+        if len(new_lines) < len(old_lines) or new_lines[: len(old_lines)] != old_lines:
+            print("::error ::memory/log.jsonl must be append-only")
+            return 1
+    elif not new_lines:
+        print("::error ::memory/log.jsonl cannot be empty")
+        return 1
+
+    appended = new_lines[len(old_lines) :] if old_lines else new_lines
+    for line in appended:
+        try:
+            record = json.loads(line)
+        except json.JSONDecodeError as exc:
+            print(f"::error ::invalid JSON line in memory/log.jsonl: {exc}")
+            return 1
+        for field in ("ts", "actor", "summary", "ref", "artifacts", "signatures"):
+            if field not in record:
+                print(f"::error ::missing '{field}' in memory/log.jsonl entry")
+                return 1
+        if not isinstance(record.get("artifacts"), list) or not isinstance(record.get("signatures"), list):
+            print("::error ::'artifacts' and 'signatures' must be lists")
+            return 1
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tools/memory/log-entry.py
+++ b/tools/memory/log-entry.py
@@ -1,0 +1,60 @@
+#!/usr/bin/env python3
+"""Append a memory log entry."""
+from __future__ import annotations
+
+import argparse
+import datetime as dt
+import json
+import subprocess
+from pathlib import Path
+
+LOG_PATH = Path(__file__).resolve().parents[2] / "memory" / "log.jsonl"
+
+
+def default_actor() -> str:
+    try:
+        result = subprocess.run(
+            ["git", "config", "user.name"],
+            check=True,
+            capture_output=True,
+            text=True,
+        )
+        name = result.stdout.strip()
+        return name or "unknown"
+    except subprocess.CalledProcessError:
+        return "unknown"
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Append a line to memory/log.jsonl")
+    parser.add_argument("--summary", required=True)
+    parser.add_argument("--ref", required=True, help="Branch/PR/commit reference")
+    parser.add_argument("--actor", default=default_actor())
+    parser.add_argument("--artifact", action="append", default=[], help="Artifact path or URL")
+    parser.add_argument("--signature", action="append", default=[], help="Signature identifier")
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    if not LOG_PATH.exists():
+        raise SystemExit("memory/log.jsonl missing")
+
+    record = {
+        "ts": dt.datetime.utcnow().replace(microsecond=0).isoformat() + "Z",
+        "actor": args.actor,
+        "summary": args.summary,
+        "ref": args.ref,
+        "artifacts": args.artifact,
+        "signatures": args.signature,
+    }
+
+    with LOG_PATH.open("a", encoding="utf-8") as handle:
+        json.dump(record, handle, ensure_ascii=False)
+        handle.write("\n")
+
+    print("Appended memory entry", record["ts"], "->", LOG_PATH)
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/memory/query.py
+++ b/tools/memory/query.py
@@ -1,0 +1,69 @@
+#!/usr/bin/env python3
+"""Query memory/log.jsonl entries."""
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+
+LOG_PATH = Path(__file__).resolve().parents[2] / "memory" / "log.jsonl"
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Display recent memory entries")
+    parser.add_argument("--limit", type=int, default=5, help="Number of entries to display")
+    parser.add_argument("--actor", help="Filter by actor", default=None)
+    parser.add_argument("--ref", help="Filter by ref substring", default=None)
+    return parser.parse_args()
+
+
+def load_entries() -> list[dict]:
+    entries: list[dict] = []
+    with LOG_PATH.open("r", encoding="utf-8") as handle:
+        for line in handle:
+            line = line.strip()
+            if not line:
+                continue
+            entries.append(json.loads(line))
+    return entries
+
+
+def format_entry(entry: dict) -> str:
+    artifacts = ", ".join(entry.get("artifacts", [])) or "-"
+    signatures = ", ".join(entry.get("signatures", [])) or "-"
+    return (
+        f"{entry['ts']} | {entry['actor']} | {entry['summary']}\n"
+        f"  ref: {entry['ref']}\n"
+        f"  artifacts: {artifacts}\n"
+        f"  signatures: {signatures}"
+    )
+
+
+def main() -> None:
+    if not LOG_PATH.exists():
+        raise SystemExit("memory/log.jsonl missing")
+
+    args = parse_args()
+    entries = load_entries()
+
+    filtered = []
+    for entry in reversed(entries):  # newest first
+        if args.actor and entry.get("actor") != args.actor:
+            continue
+        if args.ref and args.ref not in entry.get("ref", ""):
+            continue
+        filtered.append(entry)
+        if len(filtered) >= args.limit:
+            break
+
+    if not filtered:
+        print("No entries found")
+        return
+
+    for entry in filtered:
+        print(format_entry(entry))
+        print()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add docs/policy/iteration-memory.md outlining memory and iteration policy
- introduce memory/log.jsonl with append-only entries plus helper tool
- enforce CI gate that requires append-only log updates for watched changes

## Alignment Note (L0–L3)
This change improves Observation/Coherence by providing a persistent, auditable memory scaffold and gating changes that bypass it. No canon (governance/core/**) or capsule hashes modified.
